### PR TITLE
Addresses issue #13: Other fluid types and air

### DIFF
--- a/src/mopeka_iot_ble/mopeka_types.py
+++ b/src/mopeka_iot_ble/mopeka_types.py
@@ -1,0 +1,25 @@
+"""Types for Mopeka IOT BLE advertisements.
+
+Thanks to https://github.com/spbrogan/mopeka_pro_check for
+help decoding the advertisements.
+
+MIT License applies.
+"""
+
+from enum import Enum
+
+class MediumType(Enum):
+    """Enumeration of medium types for tank level measurements."""
+
+    PROPANE = "propane"
+    AIR = "air"
+    FRESH_WATER = "fresh_water"
+    WASTE_WATER = "waste_water"
+    LIVE_WELL = "live_well"
+    BLACK_WATER = "black_water"
+    RAW_WATER = "raw_water"
+    GASOLINE = "gasoline"
+    DIESEL = "diesel"
+    LNG = "lng"
+    OIL = "oil"
+    HYDRAULIC_OIL = "hydraulic_oil"

--- a/src/mopeka_iot_ble/mopeka_types.py
+++ b/src/mopeka_iot_ble/mopeka_types.py
@@ -1,5 +1,6 @@
 """Types for Mopeka IOT BLE advertisements.
 
+
 Thanks to https://github.com/spbrogan/mopeka_pro_check for
 help decoding the advertisements.
 
@@ -7,6 +8,7 @@ MIT License applies.
 """
 
 from enum import Enum
+
 
 class MediumType(Enum):
     """Enumeration of medium types for tank level measurements."""

--- a/src/mopeka_iot_ble/parser.py
+++ b/src/mopeka_iot_ble/parser.py
@@ -8,6 +8,8 @@ MIT License applies.
 
 from __future__ import annotations
 
+from .mopeka_types import MediumType
+
 import logging
 
 from dataclasses import dataclass
@@ -23,10 +25,6 @@ from sensor_state_data import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-
-from .mopeka_types import MediumType
-
 
 # converting sensor value to height
 MOPEKA_TANK_LEVEL_COEFFICIENTS = {
@@ -46,6 +44,7 @@ MOPEKA_TANK_LEVEL_COEFFICIENTS = {
 
 MOPEKA_MANUFACTURER = 89
 MOKPEKA_PRO_SERVICE_UUID = "0000fee5-0000-1000-8000-00805f9b34fb"
+
 
 @dataclass
 class MopekaDevice:
@@ -92,6 +91,7 @@ def tank_level_to_mm(tank_level: int) -> int:
     """Convert tank level value to mm."""
     return tank_level * 10
 
+
 def tank_level_and_temp_to_mm(tank_level: int, temp: int, medium: MediumType = MediumType.PROPANE) -> int:
     """Get the tank level in mm for a given fluid type."""
     coefs = MOPEKA_TANK_LEVEL_COEFFICIENTS.get(medium)
@@ -109,20 +109,21 @@ class MopekaIOTBluetoothDeviceData(BluetoothData):
     """Data for Mopeka IOT BLE sensors."""
 
     def __init__(self) -> None:
-      super().__init__()
-      self._medium_type = MediumType.PROPANE
+        super().__init__()
+        self._medium_type = MediumType.PROPANE
 
     @property
     def medium_type(self) -> MediumType:
         return self._medium_type
 
     @medium_type.setter
-    def medium_type(self, value: MediumType) ->None:
+    def medium_type(self, value: MediumType) -> None:
         self._medium_type = value
 
     def _start_update(self, service_info: BluetoothServiceInfo) -> None:
         """Update from BLE advertisement data."""
-        _LOGGER.debug("Parsing Mopeka IOT BLE advertisement data: %s, MediumType is: %s", service_info, self._medium_type)
+        _LOGGER.debug("Parsing Mopeka IOT BLE advertisement data: %s, MediumType is: %s",
+                      service_info, self._medium_type)
         manufacturer_data = service_info.manufacturer_data
         service_uuids = service_info.service_uuids
         address = service_info.address

--- a/src/mopeka_iot_ble/parser.py
+++ b/src/mopeka_iot_ble/parser.py
@@ -9,6 +9,7 @@ MIT License applies.
 from __future__ import annotations
 
 import logging
+
 from dataclasses import dataclass
 
 from bluetooth_data_tools import short_address
@@ -24,12 +25,27 @@ from sensor_state_data import (
 _LOGGER = logging.getLogger(__name__)
 
 
-# converting sensor value to height - contact Mopeka for other fluids/gases
-MOPEKA_TANK_LEVEL_COEFFICIENTS_PROPANE = (0.573045, -0.002822, -0.00000535)
+from .mopeka_types import MediumType
+
+
+# converting sensor value to height
+MOPEKA_TANK_LEVEL_COEFFICIENTS = {
+    MediumType.PROPANE: [0.573045, -0.002822, -0.00000535],
+    MediumType.AIR: [0.153096, 0.000327, -0.000000294],
+    MediumType.FRESH_WATER: [0.600592, 0.003124, -0.00001368],
+    MediumType.WASTE_WATER: [0.600592, 0.003124, -0.00001368],
+    MediumType.LIVE_WELL: [0.600592, 0.003124, -0.00001368],
+    MediumType.BLACK_WATER: [0.600592, 0.003124, -0.00001368],
+    MediumType.RAW_WATER: [0.600592, 0.003124, -0.00001368],
+    MediumType.GASOLINE: [0.7373417462, -0.001978229885, 0.00000202162],
+    MediumType.DIESEL: [0.7373417462, -0.001978229885, 0.00000202162],
+    MediumType.LNG: [0.7373417462, -0.001978229885, 0.00000202162],
+    MediumType.OIL: [0.7373417462, -0.001978229885, 0.00000202162],
+    MediumType.HYDRAULIC_OIL: [0.7373417462, -0.001978229885, 0.00000202162],
+}
 
 MOPEKA_MANUFACTURER = 89
 MOKPEKA_PRO_SERVICE_UUID = "0000fee5-0000-1000-8000-00805f9b34fb"
-
 
 @dataclass
 class MopekaDevice:
@@ -76,15 +92,15 @@ def tank_level_to_mm(tank_level: int) -> int:
     """Convert tank level value to mm."""
     return tank_level * 10
 
-
-def tank_level_and_temp_to_mm(tank_level: int, temp: int) -> int:
-    """Get the tank level in mm."""
+def tank_level_and_temp_to_mm(tank_level: int, temp: int, medium: MediumType = MediumType.PROPANE) -> int:
+    """Get the tank level in mm for a given fluid type."""
+    coefs = MOPEKA_TANK_LEVEL_COEFFICIENTS.get(medium)
     return int(
         tank_level
         * (
-            MOPEKA_TANK_LEVEL_COEFFICIENTS_PROPANE[0]
-            + (MOPEKA_TANK_LEVEL_COEFFICIENTS_PROPANE[1] * temp)
-            + (MOPEKA_TANK_LEVEL_COEFFICIENTS_PROPANE[2] * (temp**2))
+            coefs[0]
+            + (coefs[1] * temp)
+            + (coefs[2] * (temp**2))
         )
     )
 
@@ -92,9 +108,21 @@ def tank_level_and_temp_to_mm(tank_level: int, temp: int) -> int:
 class MopekaIOTBluetoothDeviceData(BluetoothData):
     """Data for Mopeka IOT BLE sensors."""
 
+    def __init__(self) -> None:
+      super().__init__()
+      self._medium_type = MediumType.PROPANE
+
+    @property
+    def medium_type(self) -> MediumType:
+        return self._medium_type
+
+    @medium_type.setter
+    def medium_type(self, value: MediumType) ->None:
+        self._medium_type = value
+
     def _start_update(self, service_info: BluetoothServiceInfo) -> None:
         """Update from BLE advertisement data."""
-        _LOGGER.debug("Parsing Mopeka IOT BLE advertisement data: %s", service_info)
+        _LOGGER.debug("Parsing Mopeka IOT BLE advertisement data: %s, MediumType is: %s", service_info, self._medium_type)
         manufacturer_data = service_info.manufacturer_data
         service_uuids = service_info.service_uuids
         address = service_info.address
@@ -123,7 +151,7 @@ class MopekaIOTBluetoothDeviceData(BluetoothData):
         temp = data[2] & 0x7F
         temp_celsius = temp_to_celsius(temp)
         tank_level = ((int(data[4]) << 8) + data[3]) & 0x3FFF
-        tank_level_mm = tank_level_and_temp_to_mm(tank_level, temp)
+        tank_level_mm = tank_level_and_temp_to_mm(tank_level, temp, self._medium_type)
         reading_quality = data[4] >> 6
         accelerometer_x = data[8]
         accelerometer_y = data[9]

--- a/src/mopeka_iot_ble/parser.py
+++ b/src/mopeka_iot_ble/parser.py
@@ -26,8 +26,6 @@ from sensor_state_data import (
 _LOGGER = logging.getLogger(__name__)
 
 
-from .mopeka_types import MediumType
-
 # converting sensor value to height
 MOPEKA_TANK_LEVEL_COEFFICIENTS = {
     MediumType.PROPANE: [0.573045, -0.002822, -0.00000535],

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -14,12 +14,16 @@ from sensor_state_data import (
 from mopeka_iot_ble.mopeka_types import MediumType
 
 # Consider renaming the hex method to avoid the override complaint
-from mopeka_iot_ble.parser import (  # pylint: disable=redefined-builtin
+from mopeka_iot_ble.parser import (
+    mopeka_iot_ble.parser,  # pylint: disable=redefined-builtin
+)
 from mopeka_iot_ble.parser import (  # pylint: disable=redefined-builtin
     MopekaIOTBluetoothDeviceData,
     battery_to_percentage,
     battery_to_voltage,
+    from,
     hex,
+    import,
     tank_level_and_temp_to_mm,
     tank_level_to_mm,
     temp_to_celsius,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -15,6 +15,7 @@ from mopeka_iot_ble.mopeka_types import MediumType
 
 # Consider renaming the hex method to avoid the override complaint
 from mopeka_iot_ble.parser import (  # pylint: disable=redefined-builtin
+from mopeka_iot_ble.parser import (  # pylint: disable=redefined-builtin
     MopekaIOTBluetoothDeviceData,
     battery_to_percentage,
     battery_to_voltage,
@@ -990,6 +991,7 @@ def test_lippert():
     )
 
 
+
 TDR40_AIR_BAD_QUALITY_INFO = BluetoothServiceInfo(
     name="",
     address="DA:D8:AC:6A:75:10",
@@ -1027,9 +1029,11 @@ tank_level_raw = 3145  # example tank level raw value
 medium_type = MediumType.AIR
 
 
+
 def test_battery_to_voltage():
     voltage = battery_to_voltage(battery_raw)
     assert voltage == 2.78125
+
 
 
 def test_battery_to_percentage():
@@ -1037,14 +1041,17 @@ def test_battery_to_percentage():
     assert percentage == 89.4
 
 
+
 def test_temp_to_celsius():
     celsius = temp_to_celsius(temperature_raw)
     assert celsius == 37
 
 
+
 def test_tank_level_to_mm():
     mm = tank_level_to_mm(tank_level_raw)
     assert mm == 31450  # tank_level_raw * 10
+
 
 
 def test_tank_level_and_temp_to_mm():
@@ -1060,6 +1067,7 @@ def test_tank_level_and_temp_to_mm():
         )
     )
     assert tank_level_mm == expected_mm
+
 
 
 def test_parser_with_sample_data():
@@ -1086,6 +1094,7 @@ def test_parser_with_sample_data():
             + (-0.000000294 * (temperature_raw**2))  # coefs[2] * (temp ** 2)
         )
     )
+
 
 
 # Test entire parser chain
@@ -1215,6 +1224,7 @@ def test_tdr40_air_bad_quality():
         },
         events={},
     )
+
 
 
 def test_tdr40_air_low_quality():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -12,7 +12,7 @@ from sensor_state_data import (
 )
 
 # Consider renaming the hex method to avoid the override complaint
-from mopeka_iot_ble.parser import ( # pylint: disable=redefined-builtin
+from mopeka_iot_ble.parser import (  # pylint: disable=redefined-builtin
     MopekaIOTBluetoothDeviceData,
     hex,
     battery_to_voltage,
@@ -989,6 +989,7 @@ def test_lippert():
         events={},
     )
 
+
 TDR40_AIR_BAD_QUALITY_INFO = BluetoothServiceInfo(
     name="",
     address="DA:D8:AC:6A:75:10",
@@ -1025,21 +1026,26 @@ temperature_raw = 77  # example temperature raw value
 tank_level_raw = 3145  # example tank level raw value
 medium_type = MediumType.AIR
 
+
 def test_battery_to_voltage():
     voltage = battery_to_voltage(battery_raw)
     assert voltage == 2.78125
+
 
 def test_battery_to_percentage():
     percentage = battery_to_percentage(battery_raw)
     assert percentage == 89.4
 
+
 def test_temp_to_celsius():
     celsius = temp_to_celsius(temperature_raw)
     assert celsius == 37
 
+
 def test_tank_level_to_mm():
     mm = tank_level_to_mm(tank_level_raw)
     assert mm == 31450  # tank_level_raw * 10
+
 
 def test_tank_level_and_temp_to_mm():
     tank_level_mm = tank_level_and_temp_to_mm(tank_level_raw, temperature_raw, medium_type)
@@ -1052,6 +1058,7 @@ def test_tank_level_and_temp_to_mm():
         )
     )
     assert tank_level_mm == expected_mm
+
 
 def test_parser_with_sample_data():
     parser = MopekaIOTBluetoothDeviceData()
@@ -1075,6 +1082,7 @@ def test_parser_with_sample_data():
             + (-0.000000294 * (temperature_raw ** 2))  # coefs[2] * (temp ** 2)
         )
     )
+
 
 # Test entire parser chain
 def test_tdr40_air_bad_quality():
@@ -1203,6 +1211,7 @@ def test_tdr40_air_bad_quality():
         },
         events={},
     )
+
 
 def test_tdr40_air_low_quality():
     parser = MopekaIOTBluetoothDeviceData()
@@ -1408,47 +1417,47 @@ def test_tdr40_air_good_quality():
             DeviceKey(key="battery_voltage", device_id=None): SensorValue(
                 device_key=DeviceKey(key="battery_voltage", device_id=None),
                 name="Battery Voltage",
-                native_value=3.53125,
+                native_value=3.53125
             ),
             DeviceKey(key="tank_level", device_id=None): SensorValue(
                 device_key=DeviceKey(key="tank_level", device_id=None),
                 name="Tank Level",
-                native_value=729,
+                native_value=729
             ),
             DeviceKey(key="temperature", device_id=None): SensorValue(
                 device_key=DeviceKey(key="temperature", device_id=None),
                 name="Temperature",
-                native_value=24,
+                native_value=24
             ),
             DeviceKey(key="battery", device_id=None): SensorValue(
                 device_key=DeviceKey(key="battery", device_id=None),
                 name="Battery",
-                native_value=100,
+                native_value=100
             ),
             DeviceKey(key="signal_strength", device_id=None): SensorValue(
                 device_key=DeviceKey(key="signal_strength", device_id=None),
                 name="Signal Strength",
-                native_value=-50, 
+                native_value=-50
             ),
             DeviceKey(key="reading_quality", device_id=None): SensorValue(
                 device_key=DeviceKey(key="reading_quality", device_id=None),
                 name="Reading quality",
-                native_value=100,  
+                native_value=100
             ),
             DeviceKey(key="reading_quality_raw", device_id=None): SensorValue(
                 device_key=DeviceKey(key="reading_quality_raw", device_id=None),
                 name="Reading quality raw",
-                native_value=3,  
+                native_value=3
             ),
             DeviceKey(key="accelerometer_y", device_id=None): SensorValue(
                 device_key=DeviceKey(key="accelerometer_y", device_id=None),
                 name="Position Y",
-                native_value=32,  
+                native_value=32
             ),
             DeviceKey(key="accelerometer_x", device_id=None): SensorValue(
                 device_key=DeviceKey(key="accelerometer_x", device_id=None),
                 name="Position X",
-                native_value=128, 
+                native_value=128
             ),
         },
         binary_entity_descriptions={


### PR DESCRIPTION
Adds support for:

    PROPANE = "propane"
    AIR = "air"
    FRESH_WATER = "fresh_water"
    WASTE_WATER = "waste_water"
    LIVE_WELL = "live_well"
    BLACK_WATER = "black_water"
    RAW_WATER = "raw_water"
    GASOLINE = "gasoline"
    DIESEL = "diesel"
    LNG = "lng"
    OIL = "oil"
    HYDRAULIC_OIL = "hydraulic_oil"

Tested with HA using TDR40 BLE and updated pacage tests accordingly.