### PR TITLE
feat: add m1001 model

### DIFF
--- a/src/mopeka_iot_ble/parser.py
+++ b/src/mopeka_iot_ble/parser.py
@@ -44,8 +44,10 @@ MOPEKA_TANK_LEVEL_COEFFICIENTS = {
 }
 
 MOPEKA_MANUFACTURER = 89
+MOPEKA_M1001_MANUFACTURER = 13
 MOKPEKA_PRO_SERVICE_UUID = "0000fee5-0000-1000-8000-00805f9b34fb"
 MOPEKA_M1001_SERVICE_UUID = "0000ada0-0000-1000-8000-00805f9b34fb"
+M1001_ADV_LENGTH = 23  # M1001 advertisement data length (excluding trailing MAC bytes)
 
 
 @dataclass
@@ -56,7 +58,7 @@ class MopekaDevice:
 
 
 DEVICE_TYPES = {
-    0x1: MopekaDevice("M1001", "M1001", 10),
+    0x2: MopekaDevice("M1001", "M1001", M1001_ADV_LENGTH),
     0x3: MopekaDevice("M1017", "Pro Check", 10),
     0x4: MopekaDevice("Pro-200", "Pro-200", 10),
     0x5: MopekaDevice("Pro H20", "Pro Check H2O", 10),
@@ -119,16 +121,126 @@ class MopekaIOTBluetoothDeviceData(BluetoothData):
         manufacturer_data = service_info.manufacturer_data
         service_uuids = service_info.service_uuids
         address = service_info.address
+
+        # Check for M1001 (uses manufacturer ID 13 and different service UUID)
+        if (
+            MOPEKA_M1001_MANUFACTURER in manufacturer_data
+            and MOPEKA_M1001_SERVICE_UUID in service_uuids
+        ):
+            self._parse_m1001(manufacturer_data, address)
+            return
+
+        # Check for standard Mopeka devices (manufacturer ID 89)
         if MOPEKA_MANUFACTURER not in manufacturer_data or (
             MOKPEKA_PRO_SERVICE_UUID not in service_uuids
-            and MOPEKA_M1001_SERVICE_UUID not in service_uuids
         ):
             _LOGGER.debug("Not a Mopeka IOT BLE advertisement: %s", service_info)
             return
+
+        self._parse_standard(manufacturer_data, address)
+
+    def _parse_m1001(self, manufacturer_data: dict[int, bytes], address: str) -> None:
+        """
+        Parse M1001 advertisement data.
+
+        M1001 uses a different protocol with manufacturer ID 13 and a 23-byte
+        advertisement format (plus 3 bytes for MAC suffix, totaling 26 bytes).
+        """
+        data = manufacturer_data[MOPEKA_M1001_MANUFACTURER]
+
+        # M1001 data format (23+ bytes):
+        # Byte 0: Header (0x00)
+        # Byte 1: Device type (0x02 for M1001)
+        # Byte 2: Battery (raw value, different formula than standard)
+        # Byte 3: Temperature
+        # Bytes 4-5: Tank level (14-bit) + quality (2-bit)
+        # Bytes 6+: Additional sensor data
+        # Last 3 bytes: MAC address suffix
+
+        model_num = data[1]  # Device type is in byte 1 for M1001
+        if not (device_type := DEVICE_TYPES.get(model_num)):
+            _LOGGER.debug("Unsupported M1001 device type: 0x%02x", model_num)
+            return
+
+        if len(data) < M1001_ADV_LENGTH:
+            _LOGGER.debug(
+                "M1001 advertisement too short: %d bytes (expected >= %d)",
+                len(data),
+                M1001_ADV_LENGTH,
+            )
+            return
+
+        self.set_device_manufacturer("Mopeka IOT")
+        self.set_device_type(device_type.model)
+        self.set_device_name(f"{device_type.name} {short_address(address)}")
+
+        # Battery: M1001 uses different encoding
+        # Formula derived from observed values: (raw - 50) / 32
+        battery_raw = data[2]
+        battery_voltage = (battery_raw - 50) / 32
+        battery_percentage = round(
+            max(0, min(100, ((battery_voltage - 2.2) / 0.65) * 100)), 1
+        )
+
+        # Temperature: byte 3
+        temp = data[3] & 0x7F
+        button_pressed = bool(data[3] & 0x80)
+        temp_celsius = temp_to_celsius(temp)
+
+        # Tank level: bytes 4-5 (14-bit little-endian) + quality (2-bit)
+        tank_level = ((int(data[5]) << 8) + data[4]) & 0x3FFF
+        reading_quality = data[5] >> 6
+        tank_level_mm = tank_level_and_temp_to_mm(tank_level, temp, self._medium_type)
+
+        self.update_predefined_sensor(SensorLibrary.TEMPERATURE__CELSIUS, temp_celsius)
+        self.update_predefined_sensor(
+            SensorLibrary.BATTERY__PERCENTAGE, battery_percentage
+        )
+        self.update_predefined_sensor(
+            SensorLibrary.VOLTAGE__ELECTRIC_POTENTIAL_VOLT,
+            battery_voltage,
+            name="Battery Voltage",
+            key="battery_voltage",
+        )
+        self.update_predefined_binary_sensor(
+            BinarySensorDeviceClass.OCCUPANCY,
+            button_pressed,
+            key="button_pressed",
+            name="Button pressed",
+        )
+        self.update_sensor(
+            "tank_level",
+            Units.LENGTH_MILLIMETERS,
+            tank_level_mm if reading_quality >= 1 else None,
+            SensorDeviceClass.DISTANCE,
+            "Tank Level",
+        )
+        self.update_sensor(
+            "reading_quality_raw",
+            None,
+            reading_quality,
+            None,
+            "Reading quality raw",
+        )
+        self.update_sensor(
+            "reading_quality",
+            Units.PERCENTAGE,
+            round(reading_quality / 3 * 100),
+            None,
+            "Reading quality",
+        )
+        # Reading stars = (3-reading_quality) * "★" + (reading_quality * "⭐")
+
+    def _parse_standard(
+        self, manufacturer_data: dict[int, bytes], address: str
+    ) -> None:
+        """Parse standard Mopeka advertisement data (Pro, Pro Plus, etc.)."""
         data = manufacturer_data[MOPEKA_MANUFACTURER]
         model_num = data[0]
         if not (device_type := DEVICE_TYPES.get(model_num)):
-            _LOGGER.debug("Unsupported Mopeka IOT BLE advertisement: %s", service_info)
+            _LOGGER.debug(
+                "Unsupported Mopeka IOT BLE advertisement: model 0x%02x", model_num
+            )
             return
         adv_length = device_type.adv_length
         if len(data) != adv_length:

--- a/src/mopeka_iot_ble/parser.py
+++ b/src/mopeka_iot_ble/parser.py
@@ -1,4 +1,5 @@
-"""Parser for Gmopeka_iot BLE advertisements.
+"""
+Parser for Gmopeka_iot BLE advertisements.
 
 Thanks to https://github.com/spbrogan/mopeka_pro_check for
 help decoding the advertisements.
@@ -10,6 +11,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+
 from bluetooth_data_tools import short_address
 from bluetooth_sensor_state_data import BluetoothData
 from home_assistant_bluetooth import BluetoothServiceInfo
@@ -43,6 +45,7 @@ MOPEKA_TANK_LEVEL_COEFFICIENTS = {
 
 MOPEKA_MANUFACTURER = 89
 MOKPEKA_PRO_SERVICE_UUID = "0000fee5-0000-1000-8000-00805f9b34fb"
+MOPEKA_M1001_SERVICE_UUID = "0000ada0-0000-1000-8000-00805f9b34fb"
 
 
 @dataclass
@@ -53,6 +56,7 @@ class MopekaDevice:
 
 
 DEVICE_TYPES = {
+    0x1: MopekaDevice("M1001", "M1001", 10),
     0x3: MopekaDevice("M1017", "Pro Check", 10),
     0x4: MopekaDevice("Pro-200", "Pro-200", 10),
     0x5: MopekaDevice("Pro H20", "Pro Check H2O", 10),
@@ -67,7 +71,7 @@ DEVICE_TYPES = {
 
 def hex(data: bytes) -> str:
     """Return a string object containing two hexadecimal digits for each byte in the instance."""
-    return "b'{}'".format("".join(f"\\x{b:02x}" for b in data))  # noqa: E231
+    return "b'{}'".format("".join(f"\\x{b:02x}" for b in data))
 
 
 def battery_to_voltage(battery: int) -> float:
@@ -115,9 +119,9 @@ class MopekaIOTBluetoothDeviceData(BluetoothData):
         manufacturer_data = service_info.manufacturer_data
         service_uuids = service_info.service_uuids
         address = service_info.address
-        if (
-            MOPEKA_MANUFACTURER not in manufacturer_data
-            or MOKPEKA_PRO_SERVICE_UUID not in service_uuids
+        if MOPEKA_MANUFACTURER not in manufacturer_data or (
+            MOKPEKA_PRO_SERVICE_UUID not in service_uuids
+            and MOPEKA_M1001_SERVICE_UUID not in service_uuids
         ):
             _LOGGER.debug("Not a Mopeka IOT BLE advertisement: %s", service_info)
             return

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,16 +1,4 @@
 from bluetooth_sensor_state_data import BluetoothServiceInfo, SensorUpdate
-from sensor_state_data import (
-    BinarySensorDescription,
-    BinarySensorDeviceClass,
-    BinarySensorValue,
-    DeviceKey,
-    SensorDescription,
-    SensorDeviceClass,
-    SensorDeviceInfo,
-    SensorValue,
-    Units,
-)
-import pytest
 from mopeka_iot_ble import MediumType
 
 # Consider renaming the hex method to avoid the override complaint
@@ -23,6 +11,19 @@ from mopeka_iot_ble.parser import (
     tank_level_to_mm,
     temp_to_celsius,
 )
+from sensor_state_data import (
+    BinarySensorDescription,
+    BinarySensorDeviceClass,
+    BinarySensorValue,
+    DeviceKey,
+    SensorDescription,
+    SensorDeviceClass,
+    SensorDeviceInfo,
+    SensorValue,
+    Units,
+)
+
+import pytest
 
 PRO_SERVICE_BAD_QUALITY_INFO = BluetoothServiceInfo(
     name="",
@@ -102,6 +103,16 @@ CHECK_UNIVERSAL_INSTALLED_SERVICE_INFO = BluetoothServiceInfo(
     rssi=-63,
     manufacturer_data={89: b"\x0cpC\xb6\xc3\xe0\xf5\t\xfa\xe3"},
     service_uuids=["0000fee5-0000-1000-8000-00805f9b34fb"],
+    service_data={},
+    source="local",
+)
+
+M1001_SERVICE_INFO = BluetoothServiceInfo(
+    name="",
+    address="34:08:E1:29:4D:0A",
+    rssi=-41,
+    manufacturer_data={89: b"\x01pH\x00\xc0)M\n\x00\x00"},
+    service_uuids=["0000ada0-0000-1000-8000-00805f9b34fb"],
     service_data={},
     source="local",
 )
@@ -1474,6 +1485,132 @@ def test_tdr40_air_good_quality():
                 device_key=DeviceKey(key="accelerometer_x", device_id=None),
                 name="Position X",
                 native_value=128,
+            ),
+        },
+        binary_entity_descriptions={
+            DeviceKey(key="button_pressed", device_id=None): BinarySensorDescription(
+                device_key=DeviceKey(key="button_pressed", device_id=None),
+                device_class=BinarySensorDeviceClass.OCCUPANCY,
+            )
+        },
+        binary_entity_values={
+            DeviceKey(key="button_pressed", device_id=None): BinarySensorValue(
+                device_key=DeviceKey(key="button_pressed", device_id=None),
+                name="Button pressed",
+                native_value=False,
+            )
+        },
+        events={},
+    )
+
+
+def test_m1001():
+    parser = MopekaIOTBluetoothDeviceData()
+    service_info = M1001_SERVICE_INFO
+    result = parser.update(service_info)
+    assert result == SensorUpdate(
+        title=None,
+        devices={
+            None: SensorDeviceInfo(
+                name="M1001 4D0A",
+                model="M1001",
+                manufacturer="Mopeka IOT",
+                sw_version=None,
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            DeviceKey(key="battery_voltage", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="battery_voltage", device_id=None),
+                device_class=SensorDeviceClass.VOLTAGE,
+                native_unit_of_measurement=Units.ELECTRIC_POTENTIAL_VOLT,
+            ),
+            DeviceKey(key="tank_level", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="tank_level", device_id=None),
+                device_class=SensorDeviceClass.DISTANCE,
+                native_unit_of_measurement=Units.LENGTH_MILLIMETERS,
+            ),
+            DeviceKey(key="temperature", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="temperature", device_id=None),
+                device_class=SensorDeviceClass.TEMPERATURE,
+                native_unit_of_measurement=Units.TEMP_CELSIUS,
+            ),
+            DeviceKey(key="battery", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="battery", device_id=None),
+                device_class=SensorDeviceClass.BATTERY,
+                native_unit_of_measurement=Units.PERCENTAGE,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+            DeviceKey(key="reading_quality", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="reading_quality", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=Units.PERCENTAGE,
+            ),
+            DeviceKey(key="reading_quality_raw", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="reading_quality_raw", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="accelerometer_y", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="accelerometer_y", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="accelerometer_x", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="accelerometer_x", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+        },
+        entity_values={
+            DeviceKey(key="battery_voltage", device_id=None): SensorValue(
+                device_key=DeviceKey(key="battery_voltage", device_id=None),
+                name="Battery Voltage",
+                native_value=3.5,
+            ),
+            DeviceKey(key="tank_level", device_id=None): SensorValue(
+                device_key=DeviceKey(key="tank_level", device_id=None),
+                name="Tank Level",
+                native_value=0,
+            ),
+            DeviceKey(key="temperature", device_id=None): SensorValue(
+                device_key=DeviceKey(key="temperature", device_id=None),
+                name="Temperature",
+                native_value=32,
+            ),
+            DeviceKey(key="battery", device_id=None): SensorValue(
+                device_key=DeviceKey(key="battery", device_id=None),
+                name="Battery",
+                native_value=100,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorValue(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                name="Signal Strength",
+                native_value=-41,
+            ),
+            DeviceKey(key="reading_quality", device_id=None): SensorValue(
+                device_key=DeviceKey(key="reading_quality", device_id=None),
+                name="Reading quality",
+                native_value=100,
+            ),
+            DeviceKey(key="reading_quality_raw", device_id=None): SensorValue(
+                device_key=DeviceKey(key="reading_quality_raw", device_id=None),
+                name="Reading quality raw",
+                native_value=3,
+            ),
+            DeviceKey(key="accelerometer_y", device_id=None): SensorValue(
+                device_key=DeviceKey(key="accelerometer_y", device_id=None),
+                name="Position Y",
+                native_value=0,
+            ),
+            DeviceKey(key="accelerometer_x", device_id=None): SensorValue(
+                device_key=DeviceKey(key="accelerometer_x", device_id=None),
+                name="Position X",
+                native_value=0,
             ),
         },
         binary_entity_descriptions={

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -107,11 +107,26 @@ CHECK_UNIVERSAL_INSTALLED_SERVICE_INFO = BluetoothServiceInfo(
     source="local",
 )
 
-M1001_SERVICE_INFO = BluetoothServiceInfo(
+# M1001 uses manufacturer ID 13 (not 89) with a different protocol
+M1001_NOT_CONNECTED_SERVICE_INFO = BluetoothServiceInfo(
     name="",
     address="34:08:E1:29:4D:0A",
-    rssi=-41,
-    manufacturer_data={89: b"\x01pH\x00\xc0)M\n\x00\x00"},
+    rssi=-70,
+    manufacturer_data={
+        13: bytes.fromhex("00029d270c148081021d08b08104074c40c002a9294d0a")
+    },
+    service_uuids=["0000ada0-0000-1000-8000-00805f9b34fb"],
+    service_data={},
+    source="local",
+)
+
+M1001_CONNECTED_SERVICE_INFO = BluetoothServiceInfo(
+    name="",
+    address="34:08:E1:29:4D:0A",
+    rssi=-78,
+    manufacturer_data={
+        13: bytes.fromhex("00028c212854f701103e1c3001011330d08106b8294d0a")
+    },
     service_uuids=["0000ada0-0000-1000-8000-00805f9b34fb"],
     service_data={},
     source="local",
@@ -1504,9 +1519,10 @@ def test_tdr40_air_good_quality():
     )
 
 
-def test_m1001():
+def test_m1001_not_connected():
+    """Test M1001 sensor when not connected to a tank (quality=0)."""
     parser = MopekaIOTBluetoothDeviceData()
-    service_info = M1001_SERVICE_INFO
+    service_info = M1001_NOT_CONNECTED_SERVICE_INFO
     result = parser.update(service_info)
     assert result == SensorUpdate(
         title=None,
@@ -1555,32 +1571,22 @@ def test_m1001():
                 device_class=None,
                 native_unit_of_measurement=None,
             ),
-            DeviceKey(key="accelerometer_y", device_id=None): SensorDescription(
-                device_key=DeviceKey(key="accelerometer_y", device_id=None),
-                device_class=None,
-                native_unit_of_measurement=None,
-            ),
-            DeviceKey(key="accelerometer_x", device_id=None): SensorDescription(
-                device_key=DeviceKey(key="accelerometer_x", device_id=None),
-                device_class=None,
-                native_unit_of_measurement=None,
-            ),
         },
         entity_values={
             DeviceKey(key="battery_voltage", device_id=None): SensorValue(
                 device_key=DeviceKey(key="battery_voltage", device_id=None),
                 name="Battery Voltage",
-                native_value=3.5,
+                native_value=3.34375,
             ),
             DeviceKey(key="tank_level", device_id=None): SensorValue(
                 device_key=DeviceKey(key="tank_level", device_id=None),
                 name="Tank Level",
-                native_value=0,
+                native_value=None,  # No tank level when quality=0
             ),
             DeviceKey(key="temperature", device_id=None): SensorValue(
                 device_key=DeviceKey(key="temperature", device_id=None),
                 name="Temperature",
-                native_value=32,
+                native_value=-1,
             ),
             DeviceKey(key="battery", device_id=None): SensorValue(
                 device_key=DeviceKey(key="battery", device_id=None),
@@ -1590,27 +1596,124 @@ def test_m1001():
             DeviceKey(key="signal_strength", device_id=None): SensorValue(
                 device_key=DeviceKey(key="signal_strength", device_id=None),
                 name="Signal Strength",
-                native_value=-41,
+                native_value=-70,
             ),
             DeviceKey(key="reading_quality", device_id=None): SensorValue(
                 device_key=DeviceKey(key="reading_quality", device_id=None),
                 name="Reading quality",
-                native_value=100,
+                native_value=0,
             ),
             DeviceKey(key="reading_quality_raw", device_id=None): SensorValue(
                 device_key=DeviceKey(key="reading_quality_raw", device_id=None),
                 name="Reading quality raw",
-                native_value=3,
-            ),
-            DeviceKey(key="accelerometer_y", device_id=None): SensorValue(
-                device_key=DeviceKey(key="accelerometer_y", device_id=None),
-                name="Position Y",
                 native_value=0,
             ),
-            DeviceKey(key="accelerometer_x", device_id=None): SensorValue(
-                device_key=DeviceKey(key="accelerometer_x", device_id=None),
-                name="Position X",
-                native_value=0,
+        },
+        binary_entity_descriptions={
+            DeviceKey(key="button_pressed", device_id=None): BinarySensorDescription(
+                device_key=DeviceKey(key="button_pressed", device_id=None),
+                device_class=BinarySensorDeviceClass.OCCUPANCY,
+            )
+        },
+        binary_entity_values={
+            DeviceKey(key="button_pressed", device_id=None): BinarySensorValue(
+                device_key=DeviceKey(key="button_pressed", device_id=None),
+                name="Button pressed",
+                native_value=False,
+            )
+        },
+        events={},
+    )
+
+
+def test_m1001_connected():
+    """Test M1001 sensor when connected to a tank (quality>=1)."""
+    parser = MopekaIOTBluetoothDeviceData()
+    service_info = M1001_CONNECTED_SERVICE_INFO
+    result = parser.update(service_info)
+    assert result == SensorUpdate(
+        title=None,
+        devices={
+            None: SensorDeviceInfo(
+                name="M1001 4D0A",
+                model="M1001",
+                manufacturer="Mopeka IOT",
+                sw_version=None,
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            DeviceKey(key="battery_voltage", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="battery_voltage", device_id=None),
+                device_class=SensorDeviceClass.VOLTAGE,
+                native_unit_of_measurement=Units.ELECTRIC_POTENTIAL_VOLT,
+            ),
+            DeviceKey(key="tank_level", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="tank_level", device_id=None),
+                device_class=SensorDeviceClass.DISTANCE,
+                native_unit_of_measurement=Units.LENGTH_MILLIMETERS,
+            ),
+            DeviceKey(key="temperature", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="temperature", device_id=None),
+                device_class=SensorDeviceClass.TEMPERATURE,
+                native_unit_of_measurement=Units.TEMP_CELSIUS,
+            ),
+            DeviceKey(key="battery", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="battery", device_id=None),
+                device_class=SensorDeviceClass.BATTERY,
+                native_unit_of_measurement=Units.PERCENTAGE,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+            DeviceKey(key="reading_quality", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="reading_quality", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=Units.PERCENTAGE,
+            ),
+            DeviceKey(key="reading_quality_raw", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="reading_quality_raw", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+        },
+        entity_values={
+            DeviceKey(key="battery_voltage", device_id=None): SensorValue(
+                device_key=DeviceKey(key="battery_voltage", device_id=None),
+                name="Battery Voltage",
+                native_value=2.8125,
+            ),
+            DeviceKey(key="tank_level", device_id=None): SensorValue(
+                device_key=DeviceKey(key="tank_level", device_id=None),
+                name="Tank Level",
+                native_value=2446,
+            ),
+            DeviceKey(key="temperature", device_id=None): SensorValue(
+                device_key=DeviceKey(key="temperature", device_id=None),
+                name="Temperature",
+                native_value=-7,
+            ),
+            DeviceKey(key="battery", device_id=None): SensorValue(
+                device_key=DeviceKey(key="battery", device_id=None),
+                name="Battery",
+                native_value=94.2,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorValue(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                name="Signal Strength",
+                native_value=-78,
+            ),
+            DeviceKey(key="reading_quality", device_id=None): SensorValue(
+                device_key=DeviceKey(key="reading_quality", device_id=None),
+                name="Reading quality",
+                native_value=33,
+            ),
+            DeviceKey(key="reading_quality_raw", device_id=None): SensorValue(
+                device_key=DeviceKey(key="reading_quality_raw", device_id=None),
+                name="Reading quality raw",
+                native_value=1,
             ),
         },
         binary_entity_descriptions={


### PR DESCRIPTION
## Summary
This PR adds support for the Mopeka M1001 sensor model as requested in issue #67.

**Key discovery:** The M1001 uses a completely different protocol than other Mopeka sensors:
- **Manufacturer ID:** 13 (0x0d) instead of 89 (0x59)
- **Service UUID:** `0000ada0-0000-1000-8000-00805f9b34fb`
- **Data format:** 23+ bytes with different byte layout

## Changes Made
1. Added `MOPEKA_M1001_MANUFACTURER = 13` constant for the M1001's manufacturer ID
2. Added `MOPEKA_M1001_SERVICE_UUID` constant for M1001 devices
3. Changed M1001 device type from `0x01` to `0x02` (based on real data analysis)
4. Created separate `_parse_m1001()` method to handle the M1001's unique protocol
5. Updated `_start_update()` to route M1001 devices to the correct parser
6. Refactored standard Mopeka parsing into `_parse_standard()` method
7. Added tests using real M1001 advertisement data (connected and not connected to tank)

## Test Data Used
Real advertisement data from issue #67 comments:

**Not connected to tank:**
```
manufacturer_data={13: "00029d270c148081021d08b08104074c40c002a9294d0a"}
```

**Connected to tank:**
```
manufacturer_data={13: "00028c212854f701103e1c3001011330d08106b8294d0a"}
```

## Current Parser Output

**Not connected (quality=0):**
- Battery: 3.34V (100%)
- Temperature: -1°C
- Tank Level: None (quality too low)
- Reading Quality: 0%

**Connected (quality=1):**
- Battery: 2.81V (94.2%)
- Temperature: -7°C
- Tank Level: 2446mm
- Reading Quality: 33%

## Known Limitations

**The framework is in place, but some readings may be incorrect due to limited real-world data:**

1. **Temperature readings appear incorrect** (-1°C and -7°C for likely room temperature). The M1001 may use a different temperature offset than the standard -40 formula.

2. **Battery formula is estimated.** We derived `(raw - 50) / 32` from observed values, but this needs verification.

3. **Tank level calculation** uses the standard Mopeka PROPANE coefficients. This may not be correct for M1001.

4. **No accelerometer data** is exposed for M1001 as we couldn't identify which bytes contain this data.

## What Works
- M1001 devices are now detected and parsed
- Quality-based tank level filtering works (returns None when quality=0)
- Basic sensor framework is in place for battery, temperature, tank level, button press

## Next Steps
Users with M1001 hardware should:
1. Test if the sensor is detected in Home Assistant
2. Report actual vs displayed values for battery, temperature, tank level
3. Provide additional advertisement samples at different tank levels/temperatures

## Related Issues
- Fixes #67
