### PR TITLE
feat: add support for Mopeka Standard "Check" sensors

### DIFF
--- a/src/mopeka_iot_ble/parser.py
+++ b/src/mopeka_iot_ble/parser.py
@@ -46,6 +46,34 @@ MOPEKA_TANK_LEVEL_COEFFICIENTS = {
 MOPEKA_MANUFACTURER = 89
 MOKPEKA_PRO_SERVICE_UUID = "0000fee5-0000-1000-8000-00805f9b34fb"
 
+# --- Standard "Check" sensor (TI chip, service 0xADA0) -----------------------
+# Unlike the Pro line, the Standard sensor broadcasts raw ultrasonic echo data
+# and the client runs the peak-detection + speed-of-sound math (a port of
+# ESPHome's mopeka_std_check component).
+MOPEKA_STD_SERVICE_UUID = "0000ada0-0000-1000-8000-00805f9b34fb"
+# hardware id = manufacturer_data[1] & 0xCF
+MOPEKA_STD_SENSOR_TYPES = {
+    0x02: "Standard",
+    0x03: "XL",
+    0x44: "Standard",  # STANDARD_ALT
+    0x46: "eTrailer",
+}
+# 19-byte packed manufacturer payload.
+MOPEKA_STD_PACKAGE_LEN = 19
+# 1.0 = 100% propane (ESPHome default).
+MOPEKA_PROPANE_BUTANE_MIX = 1.0
+
+
+def std_speed_of_sound(temp_c: float, mix: float = MOPEKA_PROPANE_BUTANE_MIX) -> float:
+    """Return the LPG speed of sound (m/s) for the Standard distance calc."""
+    return (
+        1040.71
+        - 4.87 * temp_c
+        - 137.5 * mix
+        - 0.0107 * temp_c * temp_c
+        - 1.63 * temp_c * mix
+    )
+
 
 @dataclass
 class MopekaDevice:
@@ -118,6 +146,9 @@ class MopekaIOTBluetoothDeviceData(BluetoothData):
         manufacturer_data = service_info.manufacturer_data
         service_uuids = service_info.service_uuids
         address = service_info.address
+        if MOPEKA_STD_SERVICE_UUID in service_uuids:
+            self._update_std(service_info)
+            return
         if (
             MOPEKA_MANUFACTURER not in manufacturer_data
             or MOKPEKA_PRO_SERVICE_UUID not in service_uuids
@@ -200,3 +231,95 @@ class MopekaIOTBluetoothDeviceData(BluetoothData):
             "Reading quality",
         )
         # Reading stars = (3-reading_quality) * "★" + (reading_quality * "⭐")
+
+    def _update_std(self, service_info: BluetoothServiceInfo) -> None:
+        """Decode a Standard "Check" advertisement (ported from ESPHome)."""
+        address = service_info.address
+        # The Standard sensor emits one manufacturer-data payload; ESPHome does
+        # not check the company id, only the length + hardware id byte.
+        data: bytes | None = None
+        for payload in service_info.manufacturer_data.values():
+            if (
+                len(payload) >= MOPEKA_STD_PACKAGE_LEN
+                and (payload[1] & 0xCF) in MOPEKA_STD_SENSOR_TYPES
+            ):
+                data = payload
+                break
+        if data is None:
+            _LOGGER.debug("Unsupported Mopeka Standard advertisement: %s", service_info)
+            return
+
+        model = MOPEKA_STD_SENSOR_TYPES[data[1] & 0xCF]
+        self.set_device_manufacturer("Mopeka IOT")
+        self.set_device_type(f"{model} Check")
+        self.set_device_name(f"{model} Check {short_address(address)}")
+
+        raw_voltage = data[2]
+        raw_temp = data[3] & 0x3F
+        temp_celsius = -40.0 if raw_temp == 0 else (raw_temp - 25.0) * 1.776964
+        battery_voltage = (raw_voltage / 256.0) * 2.0 + 1.5
+        battery_percentage = round(
+            max(0.0, min(100.0, (battery_voltage - 2.2) / 0.65 * 100.0)), 1
+        )
+
+        # Unpack 12 (time, amplitude) pairs from three little-endian 40-bit
+        # blocks of eight 5-bit fields (LSB first).
+        times: list[int] = []
+        values: list[int] = []
+        for blk in range(3):
+            start = 4 + blk * 5
+            end = start + 5
+            raw = int.from_bytes(data[start:end], "little")
+            for m in range(4):
+                times.append(((raw >> (10 * m)) & 0x1F) + 1)
+                values.append((raw >> (10 * m + 5)) & 0x1F)
+
+        number_usable = 0
+        best_value = 0
+        best_time = 0
+        measurement_time = 0
+        for i in range(12):
+            measurement_time += times[i]
+            if values[i] != 0:
+                number_usable += 1
+                if values[i] > best_value:
+                    best_value = values[i]
+                    best_time = measurement_time
+                measurement_time = 0
+
+        distance_mm = round(std_speed_of_sound(temp_celsius) * best_time / 100.0)
+        valid = number_usable >= 1 and best_value >= 2 and best_time >= 2
+
+        self.update_predefined_sensor(
+            SensorLibrary.TEMPERATURE__CELSIUS, round(temp_celsius, 1)
+        )
+        self.update_predefined_sensor(
+            SensorLibrary.BATTERY__PERCENTAGE, battery_percentage
+        )
+        self.update_predefined_sensor(
+            SensorLibrary.VOLTAGE__ELECTRIC_POTENTIAL_VOLT,
+            round(battery_voltage, 3),
+            name="Battery Voltage",
+            key="battery_voltage",
+        )
+        self.update_sensor(
+            "tank_level",
+            Units.LENGTH_MILLIMETERS,
+            distance_mm if valid else None,
+            SensorDeviceClass.DISTANCE,
+            "Tank Level",
+        )
+        self.update_sensor(
+            "reading_quality_raw",
+            None,
+            best_value,
+            None,
+            "Reading quality raw",
+        )
+        self.update_sensor(
+            "reading_quality",
+            Units.PERCENTAGE,
+            round(best_value / 31 * 100),
+            None,
+            "Reading quality",
+        )

--- a/tests/test_standard.py
+++ b/tests/test_standard.py
@@ -1,0 +1,82 @@
+"""Tests for Mopeka Standard "Check" sensor decoding.
+
+Constructed advertisements with hand-verified expected outputs. The decoder was
+also validated against real hardware (readings matched the Mopeka Check phone
+app). Algorithm ported from ESPHome's ``mopeka_std_check`` component.
+"""
+
+from bluetooth_sensor_state_data import BluetoothServiceInfo, SensorUpdate
+
+from mopeka_iot_ble import MopekaIOTBluetoothDeviceData
+
+STD_SERVICE_UUID = "0000ada0-0000-1000-8000-00805f9b34fb"
+PRO_SERVICE_UUID = "0000fee5-0000-1000-8000-00805f9b34fb"
+
+
+def _service_info(
+    manufacturer_data: dict[int, bytes],
+    service_uuid: str,
+    address: str = "AA:BB:CC:DD:EE:F0",
+    rssi: int = -55,
+) -> BluetoothServiceInfo:
+    return BluetoothServiceInfo(
+        name="MOPEKA",
+        address=address,
+        rssi=rssi,
+        manufacturer_data=manufacturer_data,
+        service_data={},
+        service_uuids=[service_uuid],
+        source="test",
+    )
+
+
+def _values(update: SensorUpdate) -> dict[str, object]:
+    return {key.key: value.native_value for key, value in update.entity_values.items()}
+
+
+def test_standard_check_decodes() -> None:
+    """A Standard advertisement with one strong echo decodes fully."""
+    # data_1=0x02 (Standard), raw_voltage=0xE0, raw_temp=42, one strong echo
+    # (time_0=4, value_0=15) in the first measurement block.
+    data = bytes([0x00, 0x02, 0xE0, 0x2A, 0xE4, 0x03] + [0] * 13)
+    device = MopekaIOTBluetoothDeviceData()
+    service_info = _service_info({13: data}, STD_SERVICE_UUID)
+
+    assert device.supported(service_info)
+    values = _values(device.update(service_info))
+    assert values["temperature"] == 30.2
+    assert values["battery"] == 100.0
+    assert values["battery_voltage"] == 3.25
+    assert values["tank_level"] == 35
+    assert values["reading_quality_raw"] == 31
+    assert values["reading_quality"] == 100
+
+
+def test_standard_check_no_usable_echo() -> None:
+    """No usable echo -> tank level is None, temp/battery still report."""
+    data = bytes([0x00, 0x02, 0xE0, 0x2A] + [0] * 15)
+    device = MopekaIOTBluetoothDeviceData()
+    values = _values(device.update(_service_info({13: data}, STD_SERVICE_UUID)))
+    assert values["tank_level"] is None
+    assert values["temperature"] == 30.2
+    assert values["battery"] == 100.0
+
+
+def test_standard_check_unsupported_hardware_id() -> None:
+    """An unknown hardware id on the Standard service is ignored."""
+    data = bytes([0x00, 0x11, 0xE0, 0x2A] + [0] * 15)
+    device = MopekaIOTBluetoothDeviceData()
+    assert not device.supported(_service_info({13: data}, STD_SERVICE_UUID))
+
+
+def test_pro_still_supported() -> None:
+    """The Pro path is unaffected by adding Standard support."""
+    data = bytes([0x0C, 90, 60, 0x10, 0x40, 0, 0, 0, 7, 9])
+    device = MopekaIOTBluetoothDeviceData()
+    values = _values(
+        device.update(
+            _service_info({89: data}, PRO_SERVICE_UUID, address="AA:BB:CC:DD:EE:F1")
+        )
+    )
+    assert values["temperature"] == 20
+    assert values["tank_level"] == 6


### PR DESCRIPTION
## What / why

The decode in `mopeka-iot-ble` currently supports only the **Pro** family (Nordic manufacturer `0x59`, service `0xFEE5`). The original **Standard "Check"** sensor (e.g. Mopeka `8015004`) is a different device — a TI chip advertising service UUID **`0xADA0`** — and is silently dropped today.

Unlike the Pro (which computes the level on-device), the Standard sensor broadcasts **raw ultrasonic echo data** (12 time/amplitude pairs); the client must run peak-detection and the LPG speed-of-sound calculation. This ports that algorithm from ESPHome's [`mopeka_std_check`](https://esphome.io/components/sensor/mopeka_std_check/).

## Changes

- Minimal diff: `_start_update` gains one guard that routes Standard adverts (service `0xADA0`) to a new `_update_std` method. **The existing Pro path is untouched.**
- `_update_std` emits the same keys as the Pro path where applicable: `tank_level` (mm), `temperature`, `battery`, `battery_voltage`, `reading_quality`, `reading_quality_raw`.
- Supported Standard hardware ids: Standard (`0x02`), XL (`0x03`), Standard-Alt (`0x44`), eTrailer (`0x46`).
- `tests/test_standard.py`: full decode, no-usable-echo, unsupported-id, and a Pro-path regression check.

## Validation

Validated against **real hardware** — a Mopeka Standard Check sensor decodes to values matching the **Mopeka Check phone app** (20 lb tank reading, temperature, battery). Tests use constructed advertisements with hand-verified expected outputs.

## Notes

- Opened as a **draft** to let CI validate. Happy to adjust to conventions (e.g. convert the value-based tests to the full `SensorUpdate` snapshot style used in `test_parser.py`).
- Left the package version bump to the maintainer's release process.
- Companion Home Assistant core change (separate PR): add a `0xADA0` Bluetooth matcher to the `mopeka` integration manifest so these are discovered; the existing config flow + sensor descriptions already handle the emitted entities.

Credit: decoding algorithm ported from ESPHome (`mopeka_std_check`).