### PR TITLE
chore: remove shebang from setup.py shim

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # This is a shim to allow GitHub to detect the package, build is done with poetry
 # Taken from https://github.com/Textualize/rich
 


### PR DESCRIPTION
The pre-commit autoupdate in #84 bumps ruff to 0.16.1, which flags EXE001 on setup.py because the file has a shebang but is not executable. The file is a shim for GitHub package detection and is never run directly, so drop the shebang. The other new ruff findings are import sorts that pre-commit.ci already autofixed on the #84 branch, so that PR goes green once this lands and the branch is updated.