### PR TITLE
ci: validate the PR title instead of individual commit messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,17 +20,6 @@ jobs:
           python-version: "3.13"
       - uses: pre-commit/action@v3.0.0
 
-  # Make sure commit messages follow the conventional commits convention:
-  # https://www.conventionalcommits.org
-  commitlint:
-    name: Lint Commit Messages
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v5.3.0
-
   test:
     strategy:
       fail-fast: false
@@ -69,7 +58,6 @@ jobs:
     needs:
       - test
       - lint
-      - commitlint
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,49 @@
+name: Lint PR Title
+
+# GitHub uses the pull request title as the commit subject when "Squash and
+# merge" is used. When the repo is configured for squash-merge with the PR
+# title as the commit title, individual commits on a PR branch are discarded
+# by the squash, so this workflow — which validates the PR title against the
+# Conventional Commits spec — is the sole enforcement point for the format of
+# the commit that lands on main.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Conventional Commits types accepted by python-semantic-release.
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+          requireScope: false
+          # Subject (text after the type/scope) must start lowercase.
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.


### PR DESCRIPTION
Adds the same PR title workflow pySwitchBot uses, amannn/action-semantic-pull-request checking the title against Conventional Commits with the types python-semantic-release understands. With squash merge the PR title becomes the commit that lands on main, so linting every branch commit adds friction without protecting anything; the commitlint job is removed from CI and from the release job's needs list.